### PR TITLE
Fix clippy::unnecessary_to_owned warning

### DIFF
--- a/src/tf_buffer.rs
+++ b/src/tf_buffer.rs
@@ -88,7 +88,7 @@ impl TfBuffer {
             }
             if let Some(children) = self.child_transform_index.get(&current_node) {
                 for v in children {
-                    if visited.contains(&v.to_string()) {
+                    if visited.contains(v) {
                         continue;
                     }
 


### PR DESCRIPTION
```text
warning: unnecessary use of `to_string`
  --> src/tf_buffer.rs:91:41
   |
91 |                     if visited.contains(&v.to_string()) {
   |                                         ^^^^^^^^^^^^^^ help: use: `v`
   |
   = note: `#[warn(clippy::unnecessary_to_owned)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned
```