### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/tf_r2r/src/tf_buffer.rs
+++ b/tf_r2r/src/tf_buffer.rs
@@ -99,7 +99,7 @@ impl TfBuffer {
                             child: v.clone(),
                             parent: current_node.clone(),
                         })
-                        .map_or(false, |chain| chain.has_valid_transform(time))
+                        .is_some_and(|chain| chain.has_valid_transform(time))
                     {
                         parents.insert(v.to_string(), current_node.clone());
                         frontier.push_front(v.to_string());

--- a/tf_rosrust/src/tf_buffer.rs
+++ b/tf_rosrust/src/tf_buffer.rs
@@ -98,7 +98,7 @@ impl TfBuffer {
                             child: v.clone(),
                             parent: current_node.clone(),
                         })
-                        .map_or(false, |chain| chain.has_valid_transform(time))
+                        .is_some_and(|chain| chain.has_valid_transform(time))
                     {
                         parents.insert(v.to_string(), current_node.clone());
                         frontier.push_front(v.to_string());


### PR DESCRIPTION
test and clippy jobs are now failing to install ROS2 due to they use ubuntu-latest runner that [recently updated to ubuntu-24.04](https://github.com/actions/runner-images/issues/10636).
https://github.com/smilerobotics/tf_rosrust/actions/runs/12734634372/job/35492439307